### PR TITLE
fix shifting of PVM_EncGenSteps

### DIFF
--- a/src/bruker_sequence.jl
+++ b/src/bruker_sequence.jl
@@ -47,8 +47,8 @@ function RawAcquisitionData_MP2RAGE(b::BrukerFile)
                                    numRep))
   end
 
-  encSteps1 = parse.(Int,b["PVM_EncGenSteps1"]).+round(Int,N[2]/2)
-  encSteps2 = parse.(Int,b["PVM_EncGenSteps2"]).+round(Int,N[3]/2)
+  encSteps1 = parse.(Int,b["PVM_EncGenSteps1"]).+floor(Int,N[2]/2)
+  encSteps2 = parse.(Int,b["PVM_EncGenSteps2"]).+floor(Int,N[3]/2)
 
   objOrd = MRIFiles.acqObjOrder(b)
   objOrd = objOrd.-minimum(objOrd)


### PR DESCRIPTION
A `BoundsError` occurs during reconstruction if an encoding matrix dimension is an odd number and `round` causes a rounding up instead of down.

E.g., if N[3] = 143, then `round(Int, N[3]/2)` = 72, while `PVM_EncGenSteps2` ranges from -71 to 71.